### PR TITLE
Upgrade from EventStore TCP client to gRPC

### DIFF
--- a/chapter13/src/Marketplace.Ads.Integration/Module.cs
+++ b/chapter13/src/Marketplace.Ads.Integration/Module.cs
@@ -1,6 +1,5 @@
 using System;
 using EventStore.Client;
-using EventStore.ClientAPI;
 using Marketplace.Ads.Integration.ClassifiedAds;
 using Marketplace.EventSourcing;
 using Marketplace.EventStore;
@@ -33,12 +32,11 @@ namespace Marketplace.Ads.Integration
                         => c.GetRavenStore()
                             .OpenAsyncSession(databaseName);
 
-                    var connection = c.GetEsConnection();
-                    var client = c.GetEsClient();
+                    var client = c.GetEventStoreClient();
                     var eventStore = c.GetEventStore();
 
                     return new SubscriptionManager(
-                        connection,
+                        client,
                         new EsCheckpointStore(
                             client, SubscriptionName
                         ),
@@ -66,12 +64,7 @@ namespace Marketplace.Ads.Integration
         )
             => provider.GetRequiredService<IEventStore>();
 
-        static IEventStoreConnection GetEsConnection(
-            this IServiceProvider provider
-        )
-            => provider.GetRequiredService<IEventStoreConnection>();
-        
-        static EventStoreClient GetEsClient(
+        static EventStoreClient GetEventStoreClient(
             this IServiceProvider provider
         )
             => provider.GetRequiredService<EventStoreClient>();

--- a/chapter13/src/Marketplace.Ads.Integration/Module.cs
+++ b/chapter13/src/Marketplace.Ads.Integration/Module.cs
@@ -1,4 +1,5 @@
 using System;
+using EventStore.Client;
 using EventStore.ClientAPI;
 using Marketplace.Ads.Integration.ClassifiedAds;
 using Marketplace.EventSourcing;
@@ -33,12 +34,13 @@ namespace Marketplace.Ads.Integration
                             .OpenAsyncSession(databaseName);
 
                     var connection = c.GetEsConnection();
+                    var client = c.GetEsClient();
                     var eventStore = c.GetEventStore();
 
                     return new SubscriptionManager(
                         connection,
                         new EsCheckpointStore(
-                            connection, SubscriptionName
+                            client, SubscriptionName
                         ),
                         SubscriptionName,
                         StreamName.AllStream,
@@ -68,5 +70,10 @@ namespace Marketplace.Ads.Integration
             this IServiceProvider provider
         )
             => provider.GetRequiredService<IEventStoreConnection>();
+        
+        static EventStoreClient GetEsClient(
+            this IServiceProvider provider
+        )
+            => provider.GetRequiredService<EventStoreClient>();
     }
 }

--- a/chapter13/src/Marketplace.Ads/Module.cs
+++ b/chapter13/src/Marketplace.Ads/Module.cs
@@ -1,5 +1,5 @@
 using System;
-using EventStore.ClientAPI;
+using EventStore.Client;
 using Marketplace.Ads.ClassifiedAds;
 using Marketplace.Ads.Domain.Shared;
 using Marketplace.Ads.Queries.Projections;
@@ -48,7 +48,7 @@ namespace Marketplace.Ads
                             .OpenAsyncSession(databaseName);
 
                     return new SubscriptionManager(
-                        c.GetEsConnection(),
+                        c.GetEventStoreClient(),
                         new RavenDbCheckpointStore(
                             GetSession, SubscriptionName
                         ),
@@ -79,12 +79,13 @@ namespace Marketplace.Ads
         )
             => provider.GetRequiredService<IDocumentStore>();
         
-        static IEventStoreConnection GetEsConnection(
-            this IServiceProvider provider
-        )
-            => provider.GetRequiredService<IEventStoreConnection>();
 
         static IAggregateStore GetAggregateStore(this IServiceProvider provider)
             => provider.GetRequiredService<IAggregateStore>();
+        
+        static EventStoreClient GetEventStoreClient(
+            this IServiceProvider provider
+        )
+            => provider.GetRequiredService<EventStoreClient>();
     }
 }

--- a/chapter13/src/Marketplace.EventSourcing/ICheckpointStore.cs
+++ b/chapter13/src/Marketplace.EventSourcing/ICheckpointStore.cs
@@ -4,7 +4,7 @@ namespace Marketplace.EventSourcing
 {
     public interface ICheckpointStore
     {
-        Task<long?> GetCheckpoint();
-        Task StoreCheckpoint(long? checkpoint);
+        Task<ulong?> GetCheckpoint();
+        Task StoreCheckpoint(ulong? checkpoint);
     }
 }

--- a/chapter13/src/Marketplace.EventStore/EsCheckpointStore.cs
+++ b/chapter13/src/Marketplace.EventStore/EsCheckpointStore.cs
@@ -1,37 +1,45 @@
-using System;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
-using EventStore.ClientAPI;
+using EventStore.Client;
 using Marketplace.EventSourcing;
-using Newtonsoft.Json;
+using EventData = EventStore.Client.EventData;
+using ResolvedEvent = EventStore.Client.ResolvedEvent;
+using StreamMetadata = EventStore.Client.StreamMetadata;
+using StreamPosition = EventStore.Client.StreamPosition;
 
 namespace Marketplace.EventStore
 {
     public class EsCheckpointStore : ICheckpointStore
     {
         const string CheckpointStreamPrefix = "checkpoint:";
-        readonly IEventStoreConnection _connection;
+        readonly EventStoreClient _client;
         readonly string _streamName;
 
         public EsCheckpointStore(
-            IEventStoreConnection connection,
+            EventStoreClient client,
             string subscriptionName)
         {
-            _connection = connection;
+            _client = client;
             _streamName = CheckpointStreamPrefix + subscriptionName;
         }
 
-        public async Task<long?> GetCheckpoint()
+        public async Task<ulong?> GetCheckpoint()
         {
-            var slice = await _connection
-                .ReadStreamEventsBackwardAsync(_streamName, -1, 1, false);
+            await using var readResult = _client.ReadStreamAsync(
+                Direction.Backwards,
+                _streamName,
+                StreamPosition.End,
+                1
+            );
 
-            var eventData = slice.Events.FirstOrDefault();
-
+            var eventData = await readResult
+                .FirstOrDefaultAsync();
+            
             if (eventData.Equals(default(ResolvedEvent)))
             {
-                await StoreCheckpoint(AllCheckpoint.AllStart?.CommitPosition);
+                await StoreCheckpoint(null);
                 await SetStreamMaxCount();
                 return null;
             }
@@ -39,42 +47,40 @@ namespace Marketplace.EventStore
             return eventData.Deserialize<Checkpoint>()?.Position;
         }
 
-        public Task StoreCheckpoint(long? checkpoint)
+        public Task StoreCheckpoint(ulong? checkpoint)
         {
             var @event = new Checkpoint {Position = checkpoint};
 
             var preparedEvent =
                 new EventData(
-                    Guid.NewGuid(),
+                    Uuid.NewUuid(),
                     "$checkpoint",
-                    true,
                     Encoding.UTF8.GetBytes(
-                        JsonConvert.SerializeObject(@event)
-                    ),
-                    null
+                        JsonSerializer.Serialize(@event)
+                    )
                 );
 
-            return _connection.AppendToStreamAsync(
+            return _client.AppendToStreamAsync(
                 _streamName,
-                ExpectedVersion.Any,
-                preparedEvent
+                StreamState.Any,
+                new []{ preparedEvent }
             );
         }
 
         async Task SetStreamMaxCount()
         {
-            var metadata = await _connection.GetStreamMetadataAsync(_streamName);
+            var result = await _client.GetStreamMetadataAsync(_streamName);
 
-            if (!metadata.StreamMetadata.MaxCount.HasValue)
-                await _connection.SetStreamMetadataAsync(
-                    _streamName, ExpectedVersion.Any,
-                    StreamMetadata.Create(1)
+            if (!result.Metadata.MaxCount.HasValue)
+                await _client.SetStreamMetadataAsync(
+                    _streamName, StreamState.Any,
+                    new StreamMetadata(1)
                 );
         }
 
         class Checkpoint
         {
-            public long? Position { get; set; }
+            public ulong? Position { get; set; }
         }
     }
 }

--- a/chapter13/src/Marketplace.EventStore/EsCheckpointStore.cs
+++ b/chapter13/src/Marketplace.EventStore/EsCheckpointStore.cs
@@ -34,8 +34,13 @@ namespace Marketplace.EventStore
                 1
             );
 
-            var eventData = await readResult
-                .FirstOrDefaultAsync();
+            var eventData = default(ResolvedEvent);
+
+            if (await readResult.ReadState != ReadState.StreamNotFound)
+            {
+                eventData = await readResult
+                    .FirstOrDefaultAsync();
+            }
             
             if (eventData.Equals(default(ResolvedEvent)))
             {
@@ -43,6 +48,7 @@ namespace Marketplace.EventStore
                 await SetStreamMaxCount();
                 return null;
             }
+            
 
             return eventData.Deserialize<Checkpoint>()?.Position;
         }

--- a/chapter13/src/Marketplace.EventStore/EsCheckpointStore.cs
+++ b/chapter13/src/Marketplace.EventStore/EsCheckpointStore.cs
@@ -36,7 +36,7 @@ namespace Marketplace.EventStore
                 return null;
             }
 
-            return eventData.Deserialze<Checkpoint>()?.Position;
+            return eventData.Deserialize<Checkpoint>()?.Position;
         }
 
         public Task StoreCheckpoint(long? checkpoint)

--- a/chapter13/src/Marketplace.EventStore/EventDeserializer.cs
+++ b/chapter13/src/Marketplace.EventStore/EventDeserializer.cs
@@ -1,8 +1,6 @@
 using System.Text;
-using EventStore.ClientAPI;
+using EventStore.Client;
 using Marketplace.EventSourcing;
-using Newtonsoft.Json;
-using GrpcResolvedEvent = EventStore.Client.ResolvedEvent;
 
 namespace Marketplace.EventStore
 {
@@ -11,27 +9,12 @@ namespace Marketplace.EventStore
         public static object Deserialize(this ResolvedEvent resolvedEvent)
         {
             var dataType = TypeMapper.GetType(resolvedEvent.Event.EventType);
-            var jsonData = Encoding.UTF8.GetString(resolvedEvent.Event.Data);
-            var data = JsonConvert.DeserializeObject(jsonData, dataType);
-            return data;
-        }
-
-        public static T Deserialize<T>(this ResolvedEvent resolvedEvent)
-        {
-            var jsonData = Encoding.UTF8.GetString(resolvedEvent.Event.Data);
-            return JsonConvert.DeserializeObject<T>(jsonData);
-        }
-        
-        
-        public static object Deserialize(this GrpcResolvedEvent resolvedEvent)
-        {
-            var dataType = TypeMapper.GetType(resolvedEvent.Event.EventType);
             var jsonData = Encoding.UTF8.GetString(resolvedEvent.Event.Data.Span);
             var data = System.Text.Json.JsonSerializer.Deserialize(jsonData, dataType);
             return data;
         }
 
-        public static T Deserialize<T>(this GrpcResolvedEvent resolvedEvent)
+        public static T Deserialize<T>(this ResolvedEvent resolvedEvent)
         {
             var jsonData = Encoding.UTF8.GetString(resolvedEvent.Event.Data.Span);
             return System.Text.Json.JsonSerializer.Deserialize<T>(jsonData);

--- a/chapter13/src/Marketplace.EventStore/EventDeserializer.cs
+++ b/chapter13/src/Marketplace.EventStore/EventDeserializer.cs
@@ -2,12 +2,13 @@ using System.Text;
 using EventStore.ClientAPI;
 using Marketplace.EventSourcing;
 using Newtonsoft.Json;
+using GrpcResolvedEvent = EventStore.Client.ResolvedEvent;
 
 namespace Marketplace.EventStore
 {
     public static class EventDeserializer
     {
-        public static object Deserialze(this ResolvedEvent resolvedEvent)
+        public static object Deserialize(this ResolvedEvent resolvedEvent)
         {
             var dataType = TypeMapper.GetType(resolvedEvent.Event.EventType);
             var jsonData = Encoding.UTF8.GetString(resolvedEvent.Event.Data);
@@ -15,10 +16,25 @@ namespace Marketplace.EventStore
             return data;
         }
 
-        public static T Deserialze<T>(this ResolvedEvent resolvedEvent)
+        public static T Deserialize<T>(this ResolvedEvent resolvedEvent)
         {
             var jsonData = Encoding.UTF8.GetString(resolvedEvent.Event.Data);
             return JsonConvert.DeserializeObject<T>(jsonData);
+        }
+        
+        
+        public static object Deserialize(this GrpcResolvedEvent resolvedEvent)
+        {
+            var dataType = TypeMapper.GetType(resolvedEvent.Event.EventType);
+            var jsonData = Encoding.UTF8.GetString(resolvedEvent.Event.Data.Span);
+            var data = System.Text.Json.JsonSerializer.Deserialize(jsonData, dataType);
+            return data;
+        }
+
+        public static T Deserialize<T>(this GrpcResolvedEvent resolvedEvent)
+        {
+            var jsonData = Encoding.UTF8.GetString(resolvedEvent.Event.Data.Span);
+            return System.Text.Json.JsonSerializer.Deserialize<T>(jsonData);
         }
     }
 }

--- a/chapter13/src/Marketplace.EventStore/EventStore.cs
+++ b/chapter13/src/Marketplace.EventStore/EventStore.cs
@@ -1,12 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using EventStore.Client;
 using Marketplace.EventSourcing;
 using Newtonsoft.Json;

--- a/chapter13/src/Marketplace.EventStore/EventStore.cs
+++ b/chapter13/src/Marketplace.EventStore/EventStore.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Text;
+using System.Text.Json;
 using EventStore.Client;
 using Marketplace.EventSourcing;
-using Newtonsoft.Json;
 
 namespace Marketplace.EventStore
 {
@@ -48,7 +48,7 @@ namespace Marketplace.EventStore
             );
 
             static byte[] Serialize(object data)
-                => Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(data));
+                => Encoding.UTF8.GetBytes(JsonSerializer.Serialize(data));
         }
 
         public Task AppendEvents(

--- a/chapter13/src/Marketplace.EventStore/Marketplace.EventStore.csproj
+++ b/chapter13/src/Marketplace.EventStore/Marketplace.EventStore.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="EventStore.Client" Version="21.2.1" />
+    <PackageReference Include="EventStore.Client.Grpc.Streams" Version="21.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="System.Interactive" Version="5.1.0" />

--- a/chapter13/src/Marketplace.EventStore/Marketplace.EventStore.csproj
+++ b/chapter13/src/Marketplace.EventStore/Marketplace.EventStore.csproj
@@ -9,7 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EventStore.Client" Version="21.2.1" />
     <PackageReference Include="EventStore.Client.Grpc.Streams" Version="21.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />

--- a/chapter13/src/Marketplace.EventStore/SubscriptionManager.cs
+++ b/chapter13/src/Marketplace.EventStore/SubscriptionManager.cs
@@ -91,7 +91,7 @@ namespace Marketplace.EventStore
             object @event = null;
             try
             {
-                @event = resolvedEvent.Deserialze();
+                @event = resolvedEvent.Deserialize();
 
                 _logger.LogDebug("Projecting event {Event}", @event.ToString());
 

--- a/chapter13/src/Marketplace.EventStore/SubscriptionManager.cs
+++ b/chapter13/src/Marketplace.EventStore/SubscriptionManager.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
-using EventStore.ClientAPI;
+using EventStore.Client;
 using Marketplace.EventSourcing;
 using Microsoft.Extensions.Logging;
 
@@ -12,14 +13,14 @@ namespace Marketplace.EventStore
         readonly ICheckpointStore _checkpointStore;
         readonly string _name;
         readonly StreamName _streamName;
-        readonly IEventStoreConnection _connection;
+        readonly EventStoreClient _client;
         readonly ISubscription[] _subscriptions;
-        EventStoreCatchUpSubscription _subscription;
+        StreamSubscription _subscription;
         readonly ILogger<SubscriptionManager> _logger;
         bool _isAllStream;
 
         public SubscriptionManager(
-            IEventStoreConnection connection,
+            EventStoreClient client,
             ICheckpointStore checkpointStore,
             string name,
             StreamName streamName,
@@ -27,7 +28,7 @@ namespace Marketplace.EventStore
             params ISubscription[] subscriptions
         )
         {
-            _connection = connection;
+            _client = client;
             _checkpointStore = checkpointStore;
             _name = name;
             _streamName = streamName;
@@ -38,12 +39,6 @@ namespace Marketplace.EventStore
 
         public async Task Start()
         {
-            var settings = new CatchUpSubscriptionSettings(
-                2000, 500,
-                _logger.IsEnabled(LogLevel.Debug),
-                false, _name
-            );
-
             _logger.LogDebug("Starting the projection manager...");
 
             var position = await _checkpointStore.GetCheckpoint();
@@ -53,42 +48,62 @@ namespace Marketplace.EventStore
             );
 
             _subscription = _isAllStream
-                ? (EventStoreCatchUpSubscription)
-                _connection.SubscribeToAllFrom(
-                    GetAllStreamPosition(),
-                    settings,
-                    EventAppeared,
-                    LiveProcessingStarted,
-                    SubscriptionDropped
-                )
-                : _connection.SubscribeToStreamFrom(
-                    _streamName,
-                    GetStreamPosition(),
-                    settings,
-                    EventAppeared,
-                    LiveProcessingStarted,
-                    SubscriptionDropped
-                );
+                ? await SubscribeToAll()
+                : await SubscribeToStream();
 
             _logger.LogDebug("Subscribed to $all stream");
 
-            Position? GetAllStreamPosition()
-                => position.HasValue
-                    ? new Position((long)position.Value, (long)position.Value)
-                    : AllCheckpoint.AllStart;
+            Task<StreamSubscription> SubscribeToAll()
+            {
+                if (position.HasValue)
+                {
+                    return _client.SubscribeToAllAsync(
+                        new Position(position.Value, position.Value),
+                        EventAppeared,
+                        false,
+                        SubscriptionDropped
+                    );
+                }
 
-            long? GetStreamPosition()
-                => (long?)position ?? StreamCheckpoint.StreamStart;
+                return _client.SubscribeToAllAsync(
+                    EventAppeared,
+                    false,
+                    SubscriptionDropped
+                );
+            }
+
+            Task<StreamSubscription> SubscribeToStream()
+            {
+                if (position.HasValue)
+                {
+                    return _client.SubscribeToStreamAsync(
+                        _streamName,
+                        StreamPosition.FromInt64((long)position.Value),
+                        EventAppeared,
+                        false,
+                        SubscriptionDropped
+                    );
+                }
+
+                return _client.SubscribeToStreamAsync(
+                    _streamName,
+                    EventAppeared,
+                    false,
+                    SubscriptionDropped
+                );
+            }
         }
 
         async Task EventAppeared(
-            EventStoreCatchUpSubscription _,
-            ResolvedEvent resolvedEvent
+            StreamSubscription _,
+            ResolvedEvent resolvedEvent,
+            CancellationToken ct
         )
         {
             if (resolvedEvent.Event.EventType.StartsWith("$")) return;
 
             object @event = null;
+
             try
             {
                 @event = resolvedEvent.Deserialize();
@@ -100,10 +115,9 @@ namespace Marketplace.EventStore
                 );
 
                 await _checkpointStore.StoreCheckpoint(
-                    // ReSharper disable once PossibleInvalidOperationException
                     _isAllStream
-                        ? (ulong)resolvedEvent.OriginalPosition.Value.CommitPosition
-                        : (ulong)resolvedEvent.Event.EventNumber
+                        ? resolvedEvent.OriginalPosition!.Value.CommitPosition
+                        : resolvedEvent.Event.EventNumber
                 );
             }
             catch (Exception e)
@@ -117,22 +131,15 @@ namespace Marketplace.EventStore
             }
         }
 
-        private void LiveProcessingStarted(
-            EventStoreCatchUpSubscription subscription)
-            => _logger.LogDebug(
-                "Subscription {SubscriptionName} has caught up, now processing live",
-                _name
-            );
-
         private void SubscriptionDropped(
-            EventStoreCatchUpSubscription subscription,
-            SubscriptionDropReason reason,
+            StreamSubscription subscription,
+            SubscriptionDroppedReason reason,
             Exception exc)
             => _logger.LogError(
                 "Projection {SubscriptionName} dropped with {DropReason}, Exception: {ExceptionMessage}",
                 _name, reason, $"{exc.Message} {exc.StackTrace}"
             );
 
-        public void Stop() => _subscription.Stop();
+        public void Stop() => _subscription.Dispose();
     }
 }

--- a/chapter13/src/Marketplace.EventStore/SubscriptionManager.cs
+++ b/chapter13/src/Marketplace.EventStore/SubscriptionManager.cs
@@ -74,11 +74,11 @@ namespace Marketplace.EventStore
 
             Position? GetAllStreamPosition()
                 => position.HasValue
-                    ? new Position(position.Value, position.Value)
+                    ? new Position((long)position.Value, (long)position.Value)
                     : AllCheckpoint.AllStart;
 
             long? GetStreamPosition()
-                => position ?? StreamCheckpoint.StreamStart;
+                => (long?)position ?? StreamCheckpoint.StreamStart;
         }
 
         async Task EventAppeared(
@@ -102,8 +102,8 @@ namespace Marketplace.EventStore
                 await _checkpointStore.StoreCheckpoint(
                     // ReSharper disable once PossibleInvalidOperationException
                     _isAllStream
-                        ? resolvedEvent.OriginalPosition.Value.CommitPosition
-                        : resolvedEvent.Event.EventNumber
+                        ? (ulong)resolvedEvent.OriginalPosition.Value.CommitPosition
+                        : (ulong)resolvedEvent.Event.EventNumber
                 );
             }
             catch (Exception e)

--- a/chapter13/src/Marketplace.PaidServices/Module.cs
+++ b/chapter13/src/Marketplace.PaidServices/Module.cs
@@ -1,6 +1,5 @@
 using System;
 using EventStore.Client;
-using EventStore.ClientAPI;
 using Marketplace.EventSourcing;
 using Marketplace.EventStore;
 using Marketplace.PaidServices.ClassifiedAds;
@@ -48,7 +47,7 @@ namespace Marketplace.PaidServices
                             .OpenAsyncSession(databaseName);
 
                     return new SubscriptionManager(
-                        c.GetRequiredService<IEventStoreConnection>(),
+                        c.GetEventStoreClient(),
                         new RavenDbCheckpointStore(
                             GetSession, subscriptionName
                         ),
@@ -79,14 +78,12 @@ namespace Marketplace.PaidServices
                 {
                     var service =
                         c.GetRequiredService<ClassifiedAdCommandService>();
-                    var connection =
-                        c.GetRequiredService<IEventStoreConnection>();
                     var client =
-                        c.GetRequiredService<EventStoreClient>();
+                        c.GetEventStoreClient();
                     const string subscriptionName = "servicesReactors";
 
                     return new SubscriptionManager(
-                        connection,
+                        client,
                         new EsCheckpointStore(client, subscriptionName),
                         subscriptionName,
                         StreamName.Custom(StreamNames.AdsIntegrationStream),
@@ -104,6 +101,11 @@ namespace Marketplace.PaidServices
             return builder;
         }
 
+        static EventStoreClient GetEventStoreClient(
+            this IServiceProvider provider
+        )
+            => provider.GetRequiredService<EventStoreClient>();
+        
         static IFunctionalAggregateStore GetStore(
             this IServiceProvider provider
         )

--- a/chapter13/src/Marketplace.PaidServices/Module.cs
+++ b/chapter13/src/Marketplace.PaidServices/Module.cs
@@ -1,4 +1,5 @@
 using System;
+using EventStore.Client;
 using EventStore.ClientAPI;
 using Marketplace.EventSourcing;
 using Marketplace.EventStore;
@@ -78,14 +79,15 @@ namespace Marketplace.PaidServices
                 {
                     var service =
                         c.GetRequiredService<ClassifiedAdCommandService>();
-
                     var connection =
                         c.GetRequiredService<IEventStoreConnection>();
+                    var client =
+                        c.GetRequiredService<EventStoreClient>();
                     const string subscriptionName = "servicesReactors";
 
                     return new SubscriptionManager(
                         connection,
-                        new EsCheckpointStore(connection, subscriptionName),
+                        new EsCheckpointStore(client, subscriptionName),
                         subscriptionName,
                         StreamName.Custom(StreamNames.AdsIntegrationStream),
                         c.GetRequiredService<ILogger<SubscriptionManager>>(),

--- a/chapter13/src/Marketplace.RavenDb/RavenDbCheckpointStore.cs
+++ b/chapter13/src/Marketplace.RavenDb/RavenDbCheckpointStore.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using EventStore.ClientAPI;
 using Marketplace.EventSourcing;
 using Raven.Client.Documents.Session;
 
@@ -24,7 +23,7 @@ namespace Marketplace.RavenDb
             using var session = _getSession();
 
             var checkpoint = await session.LoadAsync<Checkpoint>(_checkpointName);
-            return checkpoint?.Position ?? (ulong?)AllCheckpoint.AllStart?.CommitPosition;
+            return checkpoint?.Position;
         }
 
         public async Task StoreCheckpoint(ulong? position)

--- a/chapter13/src/Marketplace.RavenDb/RavenDbCheckpointStore.cs
+++ b/chapter13/src/Marketplace.RavenDb/RavenDbCheckpointStore.cs
@@ -19,15 +19,15 @@ namespace Marketplace.RavenDb
             _checkpointName = checkpointName;
         }
 
-        public async Task<long?> GetCheckpoint()
+        public async Task<ulong?> GetCheckpoint()
         {
             using var session = _getSession();
 
             var checkpoint = await session.LoadAsync<Checkpoint>(_checkpointName);
-            return checkpoint?.Position ?? AllCheckpoint.AllStart?.CommitPosition;
+            return checkpoint?.Position ?? (ulong?)AllCheckpoint.AllStart?.CommitPosition;
         }
 
-        public async Task StoreCheckpoint(long? position)
+        public async Task StoreCheckpoint(ulong? position)
         {
             using var session = _getSession();
 
@@ -49,7 +49,7 @@ namespace Marketplace.RavenDb
         class Checkpoint
         {
             public string Id { get; set; }
-            public long? Position { get; set; }
+            public ulong? Position { get; set; }
         }
     }
 }

--- a/chapter13/src/Marketplace.Users/Module.cs
+++ b/chapter13/src/Marketplace.Users/Module.cs
@@ -1,5 +1,5 @@
 using System;
-using EventStore.ClientAPI;
+using EventStore.Client;
 using Marketplace.EventSourcing;
 using Marketplace.EventStore;
 using Marketplace.RavenDb;
@@ -54,7 +54,7 @@ namespace Marketplace.Users
                             c.GetRequiredService<GetUsersModuleSession>();
 
                         return new SubscriptionManager(
-                            c.GetEsConnection(),
+                            c.GetEventStoreClient(),
                             new RavenDbCheckpointStore(
                                 () => getSession(),
                                 SubscriptionName
@@ -76,11 +76,11 @@ namespace Marketplace.Users
 
             return builder;
         }
-
-        static IEventStoreConnection GetEsConnection(
+        
+        static EventStoreClient GetEventStoreClient(
             this IServiceProvider provider
         )
-            => provider.GetRequiredService<IEventStoreConnection>();
+            => provider.GetRequiredService<EventStoreClient>();
 
         static IAggregateStore GetAggregateStore(this IServiceProvider provider)
             => provider.GetRequiredService<IAggregateStore>();

--- a/chapter13/src/Marketplace.Users/Projections/UserDetailsProjection.cs
+++ b/chapter13/src/Marketplace.Users/Projections/UserDetailsProjection.cs
@@ -22,7 +22,7 @@ namespace Marketplace.Users.Projections
                     () => Update(e.UserId, x => x.DisplayName = e.DisplayName),
                 V1.ProfilePhotoUploaded e =>
                     () => Update(e.UserId, x => x.PhotoUrl = e.PhotoUrl),
-                _ => (Func<Task>) null
+                _ => null
             };
 
             Task Update(Guid id, Action<ReadModels.UserDetails> update)

--- a/chapter13/src/Marketplace/Marketplace.csproj
+++ b/chapter13/src/Marketplace/Marketplace.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="RavenDB.Client" Version="5.3.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="EventStore.Client" Version="21.2.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />

--- a/chapter13/src/Marketplace/Startup.cs
+++ b/chapter13/src/Marketplace/Startup.cs
@@ -64,6 +64,7 @@ namespace Marketplace
             
             services.AddSingleton(new ImageQueryService(ImageStorage.GetFile));
             services.AddSingleton(esConnection);
+            services.AddSingleton(client);
 
             services.AddSingleton<IEventStore>(eventStore);
 

--- a/chapter13/src/Marketplace/Startup.cs
+++ b/chapter13/src/Marketplace/Startup.cs
@@ -1,4 +1,5 @@
-﻿using EventStore.ClientAPI;
+﻿using EventStore.Client;
+using EventStore.ClientAPI;
 using Marketplace.Ads;
 using Marketplace.EventSourcing;
 using Marketplace.EventStore;
@@ -48,7 +49,13 @@ namespace Marketplace
                 ConnectionSettings.Create().KeepReconnecting(),
                 Environment.ApplicationName
             );
-            var eventStore = new EventStore.EventStore(esConnection);
+
+            var client = new EventStoreClient(
+                EventStoreClientSettings.Create(
+                    Configuration["eventStore:gRPCConnectionString"]
+                )
+            );
+            var eventStore = new EventStore.EventStore(client);
             var purgomalumClient = new PurgomalumClient();
 
             var documentStore = ConfigureRavenDb(

--- a/chapter13/src/Marketplace/Startup.cs
+++ b/chapter13/src/Marketplace/Startup.cs
@@ -1,5 +1,4 @@
 ﻿using EventStore.Client;
-using EventStore.ClientAPI;
 using Marketplace.Ads;
 using Marketplace.EventSourcing;
 using Marketplace.EventStore;
@@ -44,15 +43,9 @@ namespace Marketplace
 
         public void ConfigureServices(IServiceCollection services)
         {
-            var esConnection = EventStoreConnection.Create(
-                Configuration["eventStore:connectionString"],
-                ConnectionSettings.Create().KeepReconnecting(),
-                Environment.ApplicationName
-            );
-
             var client = new EventStoreClient(
                 EventStoreClientSettings.Create(
-                    Configuration["eventStore:gRPCConnectionString"]
+                    Configuration["eventStore:connectionString"]
                 )
             );
             var eventStore = new EventStore.EventStore(client);
@@ -63,7 +56,6 @@ namespace Marketplace
             );
             
             services.AddSingleton(new ImageQueryService(ImageStorage.GetFile));
-            services.AddSingleton(esConnection);
             services.AddSingleton(client);
 
             services.AddSingleton<IEventStore>(eventStore);

--- a/chapter13/src/Marketplace/appsettings.json
+++ b/chapter13/src/Marketplace/appsettings.json
@@ -1,7 +1,6 @@
 {
   "EventStore": {
-    "connectionString": "ConnectTo=tcp://admin:changeit@localhost:1113;UseSslConnection=false;DefaultUserCredentials=admin:changeit;",
-    "gRPCConnectionString": "esdb://localhost:2113?tls=false"
+    "connectionString": "esdb://localhost:2113?tls=false"
   },
   "RavenDb": {
     "server": "http://localhost:8080",

--- a/chapter13/src/Marketplace/appsettings.json
+++ b/chapter13/src/Marketplace/appsettings.json
@@ -1,6 +1,7 @@
 {
   "EventStore": {
-    "connectionString": "ConnectTo=tcp://admin:changeit@localhost:1113;UseSslConnection=false;DefaultUserCredentials=admin:changeit;"
+    "connectionString": "ConnectTo=tcp://admin:changeit@localhost:1113;UseSslConnection=false;DefaultUserCredentials=admin:changeit;",
+    "gRPCConnectionString": "esdb://localhost:2113?tls=false"
   },
   "RavenDb": {
     "server": "http://localhost:8080",


### PR DESCRIPTION
- Moved appending and reading events to gRPC.
- Migrated subscription checkpointing logic to gRPC.
- Migrated subscription logic from TCP to gRPC client.

.NET Migration was made in https://github.com/oskardudycz/ddd-book/pull/1